### PR TITLE
Added support of mask on the table level

### DIFF
--- a/src/TableDefinitions/TableDefinition.php
+++ b/src/TableDefinitions/TableDefinition.php
@@ -41,9 +41,9 @@ class TableDefinition
         $this->query = $callable;
     }
 
-    public function mask(string $column)
+    public function mask(string $column, string $maskCharacter = 'x')
     {
-        $this->columns[$column] = ColumnDefinition::mask($column);
+        $this->columns[$column] = ColumnDefinition::mask($column, $maskCharacter);
 
         return $this;
     }


### PR DESCRIPTION
Without this change, [the documentation example](https://beyondco.de/docs/laravel-masked-db-dump/schema-definition) works incorrectly: dumps the DB but doesn't use the correct mask character.

```
return [
    'default' => DumpSchema::define()
        ->table('users', function ($table) {
            $table->mask('password', '-');
        })
];
```