### PR TITLE
Fix tests

### DIFF
--- a/src/DumpSchema.php
+++ b/src/DumpSchema.php
@@ -97,7 +97,7 @@ class DumpSchema
 
         foreach ($this->customizedTables as $tableName => $tableDefinition) {
             $table = new TableDefinition($this->getTable($tableName));
-            call_user_func_array($tableDefinition, [$table]);
+            call_user_func_array($tableDefinition, [$table, Factory::create()]);
 
             $this->dumpTables[$tableName] = $table;
         }

--- a/tests/DumperTest.php
+++ b/tests/DumperTest.php
@@ -49,7 +49,7 @@ class DumperTest extends TestCase
 
         $this->app['config']['masked-dump.default'] = DumpSchema::define()->allTables();
 
-        $this->artisan('db:dump', [
+        $this->artisan('db:masked-dump', [
             'output' => $outputFile
         ]);
 
@@ -78,7 +78,7 @@ class DumperTest extends TestCase
                 $table->mask('name');
             });
 
-        $this->artisan('db:dump', [
+        $this->artisan('db:masked-dump', [
             'output' => $outputFile
         ]);
 
@@ -107,7 +107,7 @@ class DumperTest extends TestCase
                 $table->replace('password', 'test');
             });
 
-        $this->artisan('db:dump', [
+        $this->artisan('db:masked-dump', [
             'output' => $outputFile
         ]);
 
@@ -137,7 +137,7 @@ class DumperTest extends TestCase
                 $table->replace('email', $faker->safeEmail());
             });
 
-        $this->artisan('db:dump', [
+        $this->artisan('db:masked-dump', [
             'output' => $outputFile
         ]);
 
@@ -165,7 +165,7 @@ class DumperTest extends TestCase
             ->schemaOnly('migrations')
             ->schemaOnly('users');
 
-        $this->artisan('db:dump', [
+        $this->artisan('db:masked-dump', [
             'output' => $outputFile
         ]);
 


### PR DESCRIPTION
Currently if you try to run the tests you get this error:
```
BeyondCode\LaravelMaskedDumper\Tests\DumperTest::it_can_dump_certain_tables_as_schema_only
Symfony\Component\Console\Exception\CommandNotFoundException: The command "db:dump" does not exist.
```
Because the actual command has been renamed from `db:dump` to `db:masked-dump` but the tests weren't updated.

After fixing that if you run the tests you get this one:
```
BeyondCode\LaravelMaskedDumper\Tests\DumperTest::it_can_replace_columns_with_faker_values
ArgumentCountError: Too few arguments to function BeyondCode\LaravelMaskedDumper\Tests\DumperTest::BeyondCode\LaravelMaskedDumper\Tests\{closure}(), 1 passed and exactly 2 expected
```
Because in `it_can_replace_columns_with_faker_values` we're receiving a `$faker` as dependency but we're never passing it in `DumpSchema.php`, and if we add that we become green.