### PR TITLE
Add support for PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "doctrine/dbal": "^2.0|^3.0",
         "fakerphp/faker": "^1.13",
         "illuminate/console": "^7.0|^8.0",


### PR DESCRIPTION
This was my original intention for forking the repo, but when I tried to run the tests I got the errors, so I made this PR https://github.com/beyondcode/laravel-masked-db-dump/pull/5

Now I've successfully run the tests on PHP 8 and everything seems fine.