### PR TITLE
Add method to exclude an array of table names

### DIFF
--- a/docs/schema-definition.md
+++ b/docs/schema-definition.md
@@ -2,6 +2,7 @@
 title: Dump Schema Definition
 order: 2
 ---
+
 # Dump Schema Definition
 
 Your database dump configuration takes place in the `config/masked-dump.php` file.
@@ -21,7 +22,7 @@ return [
      * Use this dump schema definition to remove, replace or mask certain parts of your database tables.
      */
     'default' => DumpSchema::define()
-    	->allTables()
+     ->allTables()
         ->table('users', function (TableDefinition $table) {
             $table->replace('name', function (Faker $faker) {
                 return $faker->name;
@@ -42,19 +43,20 @@ This ensures that all of your database tables will be represented in the dump. Y
 ```php
 return [
     'default' => DumpSchema::define()
-    	->allTables(),
+     ->allTables(),
 ];
 ```
 
 ## Exclude specific tables from dumps
 
-The `exclude()` method allows you to exclude specific tables from the dump. This can be useful if you want to exclude certain tables from the dump:
+The `exclude()` and `excludeTables()` methods allow you to exclude specific tables from the dump. This can be useful if you want to exclude certain tables from the dump:
 
 ```php
 return [
     'default' => DumpSchema::define()
             ->allTables()
-            ->exclude('password_resets'),
+            ->exclude('password_resets')
+            ->excludeTables(['user_secrets', 'admin_notes']),
 ];
 ```
 
@@ -116,28 +118,28 @@ When dumping your data, the dump will now contain a safe, randomly generated ema
 
 ## Optimizing large datasets
 
-The method TableDefinition::outputInChunksOf(int $chunkSize) allows for chunked inserts for large datasets, 
+The method TableDefinition::outputInChunksOf(int $chunkSize) allows for chunked inserts for large datasets,
 improving performance and reducing memory consumption during the dump process.
 
 ```php
 return [
     'default' => DumpSchema::define()
         ->allTables()
-        ->table('users', function($table) { 
-            return $table->outputInChunksOf(3); 
+        ->table('users', function($table) {
+            return $table->outputInChunksOf(3);
         });
 ];
 ```
 
 ## Specifying the database connection to use
 
-By default, this package will use your `default` database connection when dumping the tables. 
+By default, this package will use your `default` database connection when dumping the tables.
 You can pass the connection to the `DumpSchema::define` method, in order to specify your own database connection string:
 
 ```php
 return [
     'default' => DumpSchema::define('sqlite')
-    	->allTables()
+     ->allTables()
 ];
 ```
 
@@ -149,9 +151,9 @@ The key in the configuration array is the identifier that will be used when you 
 ```php
 return [
     'default' => DumpSchema::define()
-    	->allTables(),
+     ->allTables(),
 
     'sqlite' => DumpSchema::define('sqlite')
-    	->schemaOnly('custom_table'),
+     ->schemaOnly('custom_table'),
 ];
 ```

--- a/docs/schema-definition.md
+++ b/docs/schema-definition.md
@@ -35,7 +35,7 @@ return [
 ];
 ```
 
-## Definiting which tables to dump
+## Defining which tables to dump
 
 The dump configuration allows you to specify which tables you want to dump. The simplest form of dumping your database can be achieved by using the `allTables()` method.
 This ensures that all of your database tables will be represented in the dump. You can then go and customize how certain tables should be dumped:
@@ -118,7 +118,7 @@ When dumping your data, the dump will now contain a safe, randomly generated ema
 
 ## Optimizing large datasets
 
-The method TableDefinition::outputInChunksOf(int $chunkSize) allows for chunked inserts for large datasets,
+The method `TableDefinition::outputInChunksOf(int $chunkSize)` allows for chunked inserts for large datasets,
 improving performance and reducing memory consumption during the dump process.
 
 ```php
@@ -139,7 +139,7 @@ You can pass the connection to the `DumpSchema::define` method, in order to spec
 ```php
 return [
     'default' => DumpSchema::define('sqlite')
-     ->allTables()
+        ->allTables()
 ];
 ```
 
@@ -151,9 +151,9 @@ The key in the configuration array is the identifier that will be used when you 
 ```php
 return [
     'default' => DumpSchema::define()
-     ->allTables(),
+        ->allTables(),
 
     'sqlite' => DumpSchema::define('sqlite')
-     ->schemaOnly('custom_table'),
+        ->schemaOnly('custom_table'),
 ];
 ```

--- a/src/DumpSchema.php
+++ b/src/DumpSchema.php
@@ -50,6 +50,18 @@ class DumpSchema
     }
 
     /**
+     * @param string[] $tableNames
+     */
+    public function excludeTables(array $tableNames)
+    {
+        foreach ($tableNames as $tableName) {
+            $this->excludedTables[] = $tableName;
+        }
+
+        return $this;
+    }
+
+    /**
      * @return \Illuminate\Database\Schema\Builder
      */
     public function getBuilder()

--- a/tests/DumperTest.php
+++ b/tests/DumperTest.php
@@ -198,6 +198,32 @@ class DumperTest extends TestCase
     }
 
     /** @test */
+    public function it_does_remove_excluded_array_of_tables_from_allTables()
+    {
+        $this->loadLaravelMigrations();
+
+        DB::table('users')
+            ->insert([
+                'name' => 'Marcel',
+                'email' => 'marcel@beyondco.de',
+                'password' => 'test',
+                'created_at' => '2021-01-01 00:00:00',
+                'updated_at' => '2021-01-01 00:00:00',
+            ]);
+
+        $outputFile = base_path('test.sql');
+
+        $this->app['config']['masked-dump.default'] = DumpSchema::define()
+            ->allTables()
+            ->excludeTables(['users']);
+
+        $this->artisan('db:masked-dump', [
+            'output' => $outputFile
+        ]);
+
+        $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
+    }
+    /** @test */
     public function it_creates_chunked_insert_statements_for_a_table()
     {
         $this->loadLaravelMigrations();
@@ -224,11 +250,11 @@ class DumperTest extends TestCase
             ]);
 
         $outputFile = base_path('test.sql');
-        
+
         $this->app['config']['masked-dump.default'] = DumpSchema::define()
                             ->allTables()
-                            ->table('users', function($table) { 
-                                    return $table->outputInChunksOf(3); 
+                            ->table('users', function($table) {
+                                    return $table->outputInChunksOf(3);
                                 });
 
         $this->artisan('db:masked-dump', [

--- a/tests/__snapshots__/DumperTest__it_does_remove_excluded_array_of_tables_from_allTables__1.txt
+++ b/tests/__snapshots__/DumperTest__it_does_remove_excluded_array_of_tables_from_allTables__1.txt
@@ -1,0 +1,3 @@
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES ('1', '0001_01_01_000000_testbench_create_users_table', '1');
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES ('2', '0001_01_01_000001_testbench_create_cache_table', '1');
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES ('3', '0001_01_01_000002_testbench_create_jobs_table', '1');


### PR DESCRIPTION
This PR adds a small 'quality of life' addition to the `DumpSchema`, allowing the developer to exclude an array of table names in one go by using a new `excludeTables()` method.

**Why?**
I wanted to exclude a number of tables, and adding them each in chained `->exclude('my_table)->exclude('my_other_table')` was ruining my mojo.

This PR adds one public method to the `DumpSchema` class, a test, and a minor tweak to the docs.

This is my first of hopefully several PRs to this repo which seek to add features I've needed from it at work.