### PR TITLE
Use the new `#[Test]` Attribute

### DIFF
--- a/tests/DumperTest.php
+++ b/tests/DumperTest.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\LaravelMaskedDumper\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use BeyondCode\LaravelMaskedDumper\DumpSchema;
 use BeyondCode\LaravelMaskedDumper\LaravelMaskedDumpServiceProvider;
 use BeyondCode\LaravelMaskedDumper\TableDefinitions\TableDefinition;
@@ -30,7 +31,7 @@ class DumperTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_dump_all_tables_without_modifications()
     {
         $this->loadLaravelMigrations();
@@ -55,7 +56,7 @@ class DumperTest extends TestCase
         $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_mask_user_names()
     {
         $this->loadLaravelMigrations();
@@ -84,7 +85,7 @@ class DumperTest extends TestCase
         $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_replace_columns_with_static_values()
     {
         $this->loadLaravelMigrations();
@@ -113,7 +114,7 @@ class DumperTest extends TestCase
         $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_replace_columns_with_faker_values()
     {
         $this->loadLaravelMigrations();
@@ -143,7 +144,7 @@ class DumperTest extends TestCase
         $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_dump_certain_tables_as_schema_only()
     {
         $this->loadLaravelMigrations();
@@ -169,7 +170,7 @@ class DumperTest extends TestCase
         $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
     }
 
-    /** @test */
+    #[Test]
     public function it_does_remove_excluded_tables_from_allTables()
     {
         $this->loadLaravelMigrations();
@@ -196,7 +197,7 @@ class DumperTest extends TestCase
         $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
     }
 
-    /** @test */
+    #[Test]
     public function it_does_remove_excluded_array_of_tables_from_allTables()
     {
         $this->loadLaravelMigrations();
@@ -222,7 +223,8 @@ class DumperTest extends TestCase
 
         $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
     }
-    /** @test */
+
+    #[Test]
     public function it_creates_chunked_insert_statements_for_a_table()
     {
         $this->loadLaravelMigrations();
@@ -263,7 +265,7 @@ class DumperTest extends TestCase
         $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_include_individual_unmodified_tables()
     {
         $this->loadLaravelMigrations();
@@ -289,7 +291,7 @@ class DumperTest extends TestCase
         $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_include_an_array_of_unmodified_tables()
     {
         $this->loadLaravelMigrations();
@@ -315,7 +317,7 @@ class DumperTest extends TestCase
         $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
     }
 
-    /** @test */
+    #[Test]
     public function it_still_includes_tables_with_repeated_use_of_include()
     {
         $this->loadLaravelMigrations();


### PR DESCRIPTION
I wanted to run the test locally for another PR, but PHPunit could not find any tests inside the project. The fix was to use the new `#[Test]` Attribute.

This PR adds them for every test.