### PR TITLE
Make it possible to specify the schema the dump needs to use

### DIFF
--- a/src/Console/DumpDatabaseCommand.php
+++ b/src/Console/DumpDatabaseCommand.php
@@ -7,7 +7,7 @@ use BeyondCode\LaravelMaskedDumper\LaravelMaskedDump;
 
 class DumpDatabaseCommand extends Command
 {
-    protected $signature = 'db:masked-dump {output} {--definition=default} {--gzip}';
+    protected $signature = 'db:masked-dump {output} {--definition=default} {--gzip} {--schema=}';
 
     protected $description = 'Create a new database dump';
 
@@ -15,7 +15,7 @@ class DumpDatabaseCommand extends Command
     {
         $definition = config('masked-dump.' . $this->option('definition'));
         $definition = is_callable($definition) ? call_user_func($definition) : $definition;
-        $definition->load();
+        $definition->load($this->option('schema'));
 
         $this->info('Starting Database dump');
 

--- a/src/DumpSchema.php
+++ b/src/DumpSchema.php
@@ -121,13 +121,13 @@ class DumpSchema
         return $this->dumpTables;
     }
 
-    protected function loadAvailableTables()
+    protected function loadAvailableTables(?string $schema = null)
     {
         if ($this->availableTables !== []) {
             return;
         }
 
-        $this->availableTables = $this->createDoctrineTables($this->getBuilder()->getTables());
+        $this->availableTables = $this->createDoctrineTables($this->getBuilder()->getTables($schema));
     }
 
     protected function createDoctrineTables(array $tables): array
@@ -152,9 +152,9 @@ class DumpSchema
         return $doctrineTables;
     }
 
-    public function load()
+    public function load(?string $schema)
     {
-        $this->loadAvailableTables();
+        $this->loadAvailableTables($schema);
 
         if ($this->loadAllTables) {
             $dumpTables = collect($this->availableTables)->mapWithKeys(function (Table $table) {

--- a/tests/DumperTest.php
+++ b/tests/DumperTest.php
@@ -2,6 +2,8 @@
 
 namespace BeyondCode\LaravelMaskedDumper\Tests;
 
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
 use BeyondCode\LaravelMaskedDumper\DumpSchema;
 use BeyondCode\LaravelMaskedDumper\LaravelMaskedDumpServiceProvider;
 use BeyondCode\LaravelMaskedDumper\TableDefinitions\TableDefinition;
@@ -340,5 +342,22 @@ class DumperTest extends TestCase
         ]);
 
         $this->assertMatchesTextSnapshot(file_get_contents($outputFile));
+    }
+
+    #[Test]
+    public function it_can_specify_the_schema(): void
+    {
+        $mock = $this->partialMock(DumpSchema::class, function (MockInterface $mock) {
+            $mock->shouldReceive('load')->with('my_schema')->once();
+        });
+
+        $this->app['config']['masked-dump.default'] = $mock;
+
+        $outputFile = base_path('test.sql');
+
+        $this->artisan('db:masked-dump', [
+            'output' => $outputFile,
+            '--schema' => 'my_schema',
+        ]);
     }
 }


### PR DESCRIPTION
The package loads all available tables from all schemas into memory. This is not ideal when working in a multi-tenant environment as it can slow down the dump significantly when there are a lot of schemas available.

Another problem with loading all tables from all schemas is that it also breaks when another schema has tables that the current schema does not have. 

For example, we have a central table that holds all relevant tenant information and some other related tables. In the current setup we need to exclude these tables from the dump. But it shouldn't be loaded in the first place in my opinion.